### PR TITLE
fix: set expiry as the max value

### DIFF
--- a/token_store.go
+++ b/token_store.go
@@ -133,11 +133,16 @@ func (s *TokenStore) Create(ctx context.Context, info oauth2.TokenInfo) error {
 		item.ExpiresAt = info.GetCodeCreateAt().Add(info.GetCodeExpiresIn())
 	} else {
 		item.Access = info.GetAccess()
-		item.ExpiresAt = info.GetAccessCreateAt().Add(info.GetAccessExpiresIn())
-
+		accessExpiry := info.GetAccessCreateAt().Add(info.GetAccessExpiresIn())
+		var refreshExpiry time.Time
 		if refresh := info.GetRefresh(); refresh != "" {
 			item.Refresh = info.GetRefresh()
-			item.ExpiresAt = info.GetRefreshCreateAt().Add(info.GetRefreshExpiresIn())
+			refreshExpiry = info.GetRefreshCreateAt().Add(info.GetRefreshExpiresIn())
+		}
+		if (accessExpiry.After(refreshExpiry)) {
+			item.ExpiresAt = accessExpiry
+		} else {
+			item.ExpiresAt = refreshExpiry
 		}
 	}
 


### PR DESCRIPTION
## Description

The current gorm db sets the ExpiresAt field as the refresh tokens expiry if a refresh token exists (which is the case for us every time, because we provide a refresh token)

https://github.com/getAlby/go-oauth2-gorm/blob/7562266573c6f2f019feb71f6806002fd779fe9f/token_store.go#L138-L141

And the garbage collector keeps removing the rows in the token store with expiry < now (and also (unrelated) if the `access_token` and `refresh_token` fields are set to `""`)

And when we provide `access_token`s which are never expiring, we basically set it to `2030-01-01` timestamp in the rails app [like this.](https://github.com/getAlby/getalby.com/blob/636bc12eb5ad249fad7511cc067ebf3300940203/app/javascript/controllers/new_access_token_controller.js#L14)

So we are basically hacking the `access_token`'s expiry by setting it to a value more than `refresh_token`'s expiry which is the default as defined by the OAuth2Server as 30 days [here.](https://github.com/getAlby/oauth2server/blob/7aa749901beda4a258c2efb6a320bf65a5f57bb2/internal/tokens/config.go#L5)

So because this gorm's ExpiresAt field is giving more preference to `refresh_token`'s expiry (because usually refresh_token's expiry > access_token's expiry), this never expiring `access_token`'s ExpiresAt is set to 30 days instead of `2030-01-01`. And because the user of this `access_token` doesn't refresh it in this 30 day time period, the garbage collector simply deletes it thinking it as an unused token.


## The Fix

Give preference to whatever expiry is later :)